### PR TITLE
Improve dialog box events

### DIFF
--- a/src/components/DialogBox/styles.scss
+++ b/src/components/DialogBox/styles.scss
@@ -50,9 +50,18 @@
 
     .key-hint {
       display: block;
-      text-align: right;
+      text-align: center;
       font-size: 15px;
       color: #bec372;
+      margin-top: 12px;
+      border: 1px solid #5a5858;
+      width: 180px;
+      padding: 5px;
+      border-radius: 5px;
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      color: #fff;
     }
   }
 }

--- a/src/pages/tutorial/introduction.js
+++ b/src/pages/tutorial/introduction.js
@@ -41,7 +41,7 @@ const Introduction = (props) => {
           <>
             <DialogBox
               text={character.history}
-              speed={40}
+              speed={10}
               eraseSpeed={0}
               typingDelay={1300}
               dialogFinished={dialogFinished}


### PR DESCRIPTION
If we waited for the entire text animation, it was repeating the same text over and over again instead of moving to the next text.